### PR TITLE
[Feature] Add host parameter support

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -16,3 +16,4 @@ jobs:
         id: tinybird-action-push
         with:
           token: ${{ secrets.TINYBIRD_TOKEN }}
+          host: "https://api.us-east.tinybird.co"

--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ jobs:
         # [required]
         # Tinybird admin token. Please, use Github secrets (https://docs.github.com/en/actions/security-guides/encrypted-secrets)
         token: ${{ secrets.TINYBIRD_TOKEN }}
+        # [required]
+        host: ${{ secrets.TINYBIRD_HOST }}
         # [optional]
         # Option to force changes or not, and update existing objects. Defaults to `true`.
         force: false

--- a/action.yml
+++ b/action.yml
@@ -7,6 +7,10 @@ inputs:
     description: Tinybird admin token
     required: true
 
+  host:
+    description: Tinybird region for your account
+    required: true
+
   force:
     description: Flag to update existing objects or not
     required: false
@@ -22,6 +26,7 @@ runs:
   image: Dockerfile
   env:
     TOKEN: ${{ inputs.token }}
+    HOST: ${{ inputs.host }}
   args:
     - ${{ inputs.force}}
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,6 +1,7 @@
 #!/bin/sh -l
 
 : "${TOKEN?Tinybird token not found, please check README.md.}"
+: "${HOST?Tinybird host not found, please check README.md.}"
 : "${GITHUB_WORKSPACE?GITHUB_WORKSPACE has to be set. Did you use the actions/checkout action?}"
 : "${GITHUB_SHA?GITHUB_SHA has to be set. Did you use the actions/checkout action?}"
 
@@ -40,6 +41,6 @@ for file in $git_diff; do
   fi
 
   # Print command
-  echo "tb --token ${TOKEN} push --push-deps ${FORCE} $file ${POPULATE}"
-  tb --token "${TOKEN}" push --push-deps ${FORCE} "$file" ${POPULATE}
+  echo "tb --token ${TOKEN} --host "${HOST}" push --push-deps ${FORCE} $file ${POPULATE}"
+  tb --token "${TOKEN}" --host "${HOST}" push --push-deps ${FORCE} "$file" ${POPULATE}
 done


### PR DESCRIPTION
### Description

Resolves #1 

Add support for `host` parameter and pass it to Tinybird CLI.
Make it optional, and default to `https://api.tinybird.co`

### Technical details

Just add a new input for the Github Action, and pass it to TInybird CLI using and environment variable.