### PR TITLE
[Feature] Add host parameter support

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,43 @@
+name: Bug Report
+description: Create a bug report for the Web Analytics Starter Kit
+title: "[Bug] "
+labels: ["bug", "triage"]
+assignees:
+  - alejandromav
+body:
+  - type: markdown
+    attributes:
+      value: Thanks for taking the time to file a bug report! Please fill out this form as completely as possible.
+  - type: textarea
+    attributes:
+      label: Describe the Bug
+      description: A clear and concise description of what the bug is.
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Expected Behavior
+      description: A clear and concise description of what you expected to happen.
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: To Reproduce
+      description: Steps to reproduce the behavior
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: More details
+      description: If relevant
+    validations:
+      required: false
+  - type: markdown
+    attributes:
+      value: Before posting the issue go through the steps you've written down to make sure the steps provided are detailed and clear.
+  - type: markdown
+    attributes:
+      value: Contributors should be able to follow the steps provided in order to reproduce the bug.
+  - type: markdown
+    attributes:
+      value: These steps are used to add integration tests to ensure the same issue does not happen again. Thanks in advance!

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Ask a question
+    url: https://github.com/alejandromav/tinybird-action-push/discussions
+    about: Ask questions and discuss with other community members

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,28 @@
+name: Feature Request
+description: Create a feature request for the Web Analytiocs Starter Kit
+title: "[Feature Request] "
+labels: ["feature request", "triage"]
+assignees:
+  - alejandromav
+body:
+  - type: markdown
+    attributes:
+      value: Thanks for taking the time to file a feature request! Please fill out this form as completely as possible.
+  - type: textarea
+    attributes:
+      label: Describe the feature you'd like to request
+      description: A clear and concise description of what you want and what your use case is.
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Describe the solution you'd like
+      description: A clear and concise description of what you want to happen.
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Describe alternatives you've considered
+      description: A clear and concise description of any alternative solutions or features you've considered.
+    validations:
+      required: false

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,28 @@
+# Description
+
+Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
+
+Fixes # (issue)
+
+## Type of change
+
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] Documentation
+
+# How Has This Been Tested?
+
+Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
+
+- [ ] Test A
+- [ ] Test B
+
+# Checklist:
+
+- [ ] I have performed a self-review of my own code
+- [ ] I have commented my code, particularly in hard-to-understand areas
+- [ ] I have made corresponding changes to the documentation
+- [ ] I have added tests that prove my fix is effective or that my feature works
+- [ ] I have update the [CHANGELOG](https://github.com/alejandromav/tinybird-action-push/blob/main/CHANGELOG.md)
+- [ ] New and existing unit tests pass locally with my changes

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -3,17 +3,31 @@ name: CI
 on: [ push ]
 
 jobs:
-  hello_world_job:
+  eu_ci:
     runs-on: ubuntu-latest
-    name: Test action works
+    name: Test action works in Tinybird EU
     steps:
       # To use this repository's private action,
       # you must check out the repository
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Test Tinybird CLI, should prompt help
         uses: ./ # Uses an action in the root directory
         id: tinybird-action-push
         with:
           token: ${{ secrets.TINYBIRD_TOKEN }}
+
+  us_east_ci:
+    runs-on: ubuntu-latest
+    name: Test action works in Tinybird US East
+    steps:
+      # To use this repository's private action,
+      # you must check out the repository
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Test Tinybird CLI, should prompt help
+        uses: ./ # Uses an action in the root directory
+        id: tinybird-action-push
+        with:
+          token: ${{ secrets.TINYBIRD_TOKEN_US }}
           host: "https://api.us-east.tinybird.co"

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -16,3 +16,4 @@ jobs:
         id: tinybird-action-push
         with:
           token: ${{ secrets.TINYBIRD_TOKEN }}
+          host: "https://api.us-east.tinybird.co"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- [#1] Add support for `host` parameter
+
 ## [1.1.4] - 2022-07-05
 
 - Push deps

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,74 @@
+## Code of Conduct
+
+### Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, gender identity and expression, level of experience,
+nationality, personal appearance, race, religion, or sexual identity and
+orientation.
+
+### Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+- Using welcoming and inclusive language
+- Being respectful of differing viewpoints and experiences
+- Gracefully accepting constructive criticism
+- Focusing on what is best for the community
+- Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+- The use of sexualized language or imagery and unwelcome sexual attention or
+  advances
+- Trolling, insulting/derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or electronic
+  address, without explicit permission
+- Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+### Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+### Scope
+
+This Code of Conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community. Examples of
+representing a project or community include using an official project e-mail
+address, posting via an official social media account, or acting as an appointed
+representative at an online or offline event. Representation of a project may be
+further defined and clarified by project maintainers.
+
+### Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the project team at [hi@tinybird.co](mailto:hi@tinybird.co). All
+complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. The project team is
+obligated to maintain confidentiality with regard to the reporter of an incident.
+Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+### Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
+available at [http://contributor-covenant.org/version/1/4][version]
+
+[homepage]: http://contributor-covenant.org
+[version]: http://contributor-covenant.org/version/1/4/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,21 @@
+# How do I make a contribution?
+
+We are happy to receive pull requests contributions from the community. New features, improvements to the existing ones, minor fixes, quality code related tasks... anything else that raises the bar of the project.
+
+Branching strategy:
+
+- Create a new branch, using these prefixes: `feature/`, `doc/`, `bugfix/`, etc.
+- Set `main` as target.
+
+Every pull request must comply all of the following:
+
+- Motivation and description (with technical details).
+- Successful functional validation.
+- Successful build status.
+- No merge conflicts.
+- No dependencies conflicts.
+- Follow code style guide.
+- All tests passing.
+- Updated README and CHANGELOG if applies.
+
+If you have any doubt, please contact the maintainers.

--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ jobs:
         # [required]
         # Tinybird admin token. Please, use Github secrets (https://docs.github.com/en/actions/security-guides/encrypted-secrets)
         token: ${{ secrets.TINYBIRD_TOKEN }}
+        # [required]
+        host: ${{ secrets.TINYBIRD_HOST }}
         # [optional]
         # Option to force changes or not, and update existing objects. Defaults to `true`.
         force: false

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ jobs:
 
     steps:
     # Important: This sets up your GITHUB_WORKSPACE environment variable
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Push changes to Tinybird
       uses: alejandromav/tinybird-action-push@1.1.4
@@ -36,11 +36,18 @@ jobs:
         # [required]
         # Tinybird admin token. Please, use Github secrets (https://docs.github.com/en/actions/security-guides/encrypted-secrets)
         token: ${{ secrets.TINYBIRD_TOKEN }}
-        # [required]
-        host: ${{ secrets.TINYBIRD_HOST }}
+
+        # [optional]
+        # Tinybird host. Defaults to `https://api.tinybird.co`.
+        host: https://api.us-east.tinybird.co
+        #
+        # You can also use and env var if you don't want to reveal your Tinybird host (dedicated clusters, etc.)
+        # host: ${{ secrets.TINYBIRD_HOST }}
+
         # [optional]
         # Option to force changes or not, and update existing objects. Defaults to `true`.
         force: false
+
         # [optional]
         # Option to populate materialized views with existing data. Defaults to `false`.
         populate: true

--- a/action.yml
+++ b/action.yml
@@ -9,7 +9,8 @@ inputs:
 
   host:
     description: Tinybird region for your account
-    required: true
+    required: false
+    default: https://api.tinybird.co
 
   force:
     description: Flag to update existing objects or not

--- a/action.yml
+++ b/action.yml
@@ -7,6 +7,10 @@ inputs:
     description: Tinybird admin token
     required: true
 
+  host:
+    description: Tinybird region for your account
+    required: true
+
   force:
     description: Flag to update existing objects or not
     required: false
@@ -22,6 +26,7 @@ runs:
   image: Dockerfile
   env:
     TOKEN: ${{ inputs.token }}
+    HOST: ${{ inputs.host }}
   args:
     - ${{ inputs.force}}
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,6 +1,7 @@
 #!/bin/sh -l
 
 : "${TOKEN?Tinybird token not found, please check README.md.}"
+: "${HOST?Tinybird host not found, please check README.md.}"
 : "${GITHUB_WORKSPACE?GITHUB_WORKSPACE has to be set. Did you use the actions/checkout action?}"
 : "${GITHUB_SHA?GITHUB_SHA has to be set. Did you use the actions/checkout action?}"
 
@@ -40,6 +41,6 @@ for file in $git_diff; do
   fi
 
   # Print command
-  echo "tb --token ${TOKEN} push --push-deps ${FORCE} $file ${POPULATE}"
-  tb --token "${TOKEN}" push --push-deps ${FORCE} "$file" ${POPULATE}
+  echo "tb --token ${TOKEN} --host "${HOST}" push --push-deps ${FORCE} $file ${POPULATE}"
+  tb --token "${TOKEN}" --host "${HOST}" push --push-deps ${FORCE} "$file" ${POPULATE}
 done


### PR DESCRIPTION
### Description

Resolves #1 

Add support for `host` parameter and pass it to Tinybird CLI.
Make it optional, and default to `https://api.tinybird.co`

### Technical details

Just add a new input for the Github Action, and pass it to TInybird CLI using and environment variable.